### PR TITLE
Fix of broken Discourse.SiteSetting calls

### DIFF
--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -1,9 +1,11 @@
 export default {
 
     name: 'discourse-mathjax',
+    after: 'inject-objects',
 
     initialize: function (container) {
-        if (Discourse.SiteSettings.enable_mathjax_plugin == false) {
+        var siteSettings = container.lookup('site-settings:main');
+        if (siteSettings.enable_mathjax_plugin == false) {
             return;
         }
         var mathjaxUrl = (window.location.protocol === 'https:') ? 'https://cdn.mathjax.org/mathjax/latest/MathJax.js' : 'http://cdn.mathjax.org/mathjax/latest/MathJax.js';

--- a/assets/javascripts/tex_dialect.js
+++ b/assets/javascripts/tex_dialect.js
@@ -1,4 +1,4 @@
-if (Discourse.SiteSettings.enable_mathjax_plugin == true) {
+(function() {
     Discourse.Dialect.inlineBetween({
         start: '\\(',
         stop: '\\)',
@@ -25,8 +25,8 @@ if (Discourse.SiteSettings.enable_mathjax_plugin == true) {
         return '$$' + contents + '$$';
         }
     });
- 
- 
+
+
     Discourse.Dialect.inlineBetween({
         start: '$',
         stop: '$',
@@ -63,4 +63,4 @@ if (Discourse.SiteSettings.enable_mathjax_plugin == true) {
             return 'ˊ' + contents + 'ˊ';
         }
     });
-}
+})();


### PR DESCRIPTION
Fix of `TypeError: Discourse.SiteSettings is undefined`  described at 
https://meta.discourse.org/t/mathjax-plugin-supports-math-notation-using-latex/12826/20
This error did not impact TeX rendering, but caused issues with other plugins such as Poll. 
Probably fixes kasperpeulen/discourse-mathjax#8 too.  
Additionally updated  how site settings are accessed to follow convention introduced in  https://github.com/discourse/discourse/commit/52094fe554338a0d8f6a009c93149bae09439a4a 

Tested with latest Discourse, enabling/disabling MathJax via site preference works as expected.
