### PR TITLE
Allow configurable MathJax CDN asset URLs

### DIFF
--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -8,8 +8,7 @@ export default {
         if (siteSettings.enable_mathjax_plugin == false) {
             return;
         }
-        var mathjaxUrl = (window.location.protocol === 'https:') ? siteSettings.mathjax_https_url : siteSettings.mathjax_http_url;;
-        $LAB.script(mathjaxUrl + '?config=TeX-AMS-MML_HTMLorMML').wait(function () {
+        $LAB.script(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config).wait(function () {
 
             MathJax.Hub.Config({
                 "HTML-CSS": {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,5 @@
 en:
   site_settings:
     enable_mathjax_plugin: 'Enable MathJax plugin'
-    mathjax_http_url: 'MathJax URL for HTTP clients'
-    mathjax_https_url: 'MathJax URL for HTTPS clients'
+    mathjax_url: 'MathJax URL'
+    mathjax_config: 'MathJax config setting'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,9 +2,9 @@ mathjax_plugin:
   enable_mathjax_plugin:
     client: true
     default: false
-  mathjax_http_url:
+  mathjax_url:
     client: true
-    default: http://cdn.mathjax.org/mathjax/latest/MathJax.js
-  mathjax_https_url:
+    default: //cdn.mathjax.org/mathjax/latest/MathJax.js
+  mathjax_config:
     client: true
-    default: https://cdn.mathjax.org/mathjax/latest/MathJax.js
+    default: TeX-AMS-MML_HTMLorMML


### PR DESCRIPTION
This PR allows configuration of MathJax URLs in site settings.
https://meta.discourse.org/t/mathjax-plugin-supports-math-notation-using-latex/12826/24?u=rookus
