### PR TITLE
Trigger typesetting after post changes

### DIFF
--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -1,3 +1,5 @@
+import { decorateCooked } from 'discourse/lib/plugin-api';
+
 export default {
 
     name: 'discourse-mathjax',
@@ -61,7 +63,7 @@ export default {
                 MathJax.Hub.Queue(["Typeset", MathJax.Hub, "topic"]);
             };
 
-            Discourse.PostView.prototype.on("postViewInserted", applyBody);
+            decorateCooked(container, applyBody);
             container.lookupFactory('view:composer').prototype.on("previewRefreshed", applyPreview);
 
         });


### PR DESCRIPTION
This change insures that MathJax is triggered after various page-changing events, like inserting new posts, unhiding hidden posts, etc. [Here](https://meta.discourse.org/t/mathjax-plugin-supports-math-notation-using-latex/12826/36?u=mcg) is a discussion of those changes, and a link to a place where you can see the modified plugin in action.