### PR TITLE
load MathJax with a script tag so it knows its URL

### DIFF
--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -27,7 +27,7 @@ export default {
     const siteSettings = container.lookup('site-settings:main');
     if (!siteSettings.enable_mathjax_plugin) { return; }
 
-    loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config).then(function () {
+    loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
 
       MathJax.Hub.Config({
         "HTML-CSS": {


### PR DESCRIPTION
This fixes my issue I describe [here](https://meta.discourse.org/t/mathjax-plugin-supports-math-notation-using-latex/12826/65?u=fefrei). I don't really know why it works without this with the CDN URL, but the change should make sense in all cases.