### PR TITLE
README.md: Fix install instructions w/ Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Installation
 ## Installation on top of Docker image
 
 If you have install Discourse on Digital Ocean using a Docker image as described using the
-[Basic Docker Installation Guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL-digital-ocean.md)
+[Basic Docker Installation Guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md)
 then try this:
 
-open "/var/docker/containers/app.yml" using vim or nano.
+open "/var/discourse/containers/app.yml" using vim or nano.
 
-add 'git clone https://github.com/kasperpeulen/discourse-mathjax' in the after_code hook as follows:
+add 'git clone https://github.com/kasperpeulen/discourse-mathjax.git' in the after_code hook as follows:
 
     hooks:
       after_code:
@@ -28,11 +28,11 @@ add 'git clone https://github.com/kasperpeulen/discourse-mathjax' in the after_c
             cd: $home/plugins
             cmd:
               - mkdir -p plugins
-              - git clone https://github.com/kasperpeulen/discourse-mathjax
+              - git clone https://github.com/kasperpeulen/discourse-mathjax.git
 
-Change directory to /var/docker and run `./launcher rebuild app`
+Change directory to /var/discourse and run `./launcher rebuild app`
 
-If you edited a different yaml file such as '/var/docker/containers/image.yml' then
+If you edited a different yaml file such as '/var/discourse/containers/image.yml' then
 the command would be
 `./launcher rebuild image`.
 


### PR DESCRIPTION
- The clone command was plain wrong.
- The default path for the install now uses `/var/discourse`, not `/var/docker`.
- Also update link.