### PR TITLE
Improve installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ add 'git clone https://github.com/kasperpeulen/discourse-mathjax' in the after_c
         - exec:
             cd: $home/plugins
             cmd:
-              - mkdir -p plugins
               - git clone https://github.com/kasperpeulen/discourse-mathjax
 
 Change directory to /var/docker and run `./launcher rebuild app`


### PR DESCRIPTION
This change avoids to create an empty `/var/www/discourse/plugins/plugins` folder.

Furthermore, the folder /var/www/discourse/plugins now always exists, as poll and lazyYT plugins are shipped with Docker.