### PR TITLE
Adapt to Discourse 1.5

### DIFF
--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -19,46 +19,49 @@ function applyPreview() {
   }
 }
 
+function mathJaxConfig() {
+  MathJax.Hub.Config({
+    "HTML-CSS": {
+      preferredFont: "TeX",
+      availableFonts: ["TeX"],
+      linebreaks: {
+        automatic: true
+      },
+      EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50)
+    },
+    tex2jax: {
+      inlineMath: [
+        ["$", "$"],
+        ["\\(", "\\)"]
+      ],
+      displayMath: [
+        ["$$", "$$"],
+        ["\\[", "\\]"]
+      ],
+      processEscapes: true
+    },
+    TeX: {
+      noUndefined: {
+        attributes: {
+          mathcolor: "red",
+          mathbackground: "#FFEEEE",
+          mathsize: "90%"
+        }
+      },
+      Macros: {
+        href: "{}"
+      }
+    },
+    messageStyle: "none"
+  });
+}
+
 function oldCode(container) {
   const siteSettings = container.lookup('site-settings:main');
   if (!siteSettings.enable_mathjax_plugin) { return; }
 
   loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
-
-    MathJax.Hub.Config({
-      "HTML-CSS": {
-        preferredFont: "TeX",
-        availableFonts: ["TeX"],
-        linebreaks: {
-          automatic: true
-        },
-        EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50)
-      },
-      tex2jax: {
-        inlineMath: [
-          ["$", "$"],
-          ["\\(", "\\)"]
-        ],
-        displayMath: [
-          ["$$", "$$"],
-          ["\\[", "\\]"]
-        ],
-        processEscapes: true
-      },
-      TeX: {
-        noUndefined: {
-          attributes: {
-            mathcolor: "red",
-            mathbackground: "#FFEEEE",
-            mathsize: "90%"
-          }
-        },
-        Macros: {
-          href: "{}"
-        }
-      },
-      messageStyle: "none"
-    });
+    mathJaxConfig();
 
     decorateCooked(container, applyBody);
     container.lookupFactory('view:composer').prototype.on("previewRefreshed", applyPreview);

--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -19,53 +19,57 @@ function applyPreview() {
   }
 }
 
+function oldCode(container) {
+  const siteSettings = container.lookup('site-settings:main');
+  if (!siteSettings.enable_mathjax_plugin) { return; }
+
+  loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
+
+    MathJax.Hub.Config({
+      "HTML-CSS": {
+        preferredFont: "TeX",
+        availableFonts: ["TeX"],
+        linebreaks: {
+          automatic: true
+        },
+        EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50)
+      },
+      tex2jax: {
+        inlineMath: [
+          ["$", "$"],
+          ["\\(", "\\)"]
+        ],
+        displayMath: [
+          ["$$", "$$"],
+          ["\\[", "\\]"]
+        ],
+        processEscapes: true
+      },
+      TeX: {
+        noUndefined: {
+          attributes: {
+            mathcolor: "red",
+            mathbackground: "#FFEEEE",
+            mathsize: "90%"
+          }
+        },
+        Macros: {
+          href: "{}"
+        }
+      },
+      messageStyle: "none"
+    });
+
+    decorateCooked(container, applyBody);
+    container.lookupFactory('view:composer').prototype.on("previewRefreshed", applyPreview);
+  });
+}
+
 export default {
   name: 'discourse-mathjax',
   after: 'inject-objects',
 
   initialize: function (container) {
-    const siteSettings = container.lookup('site-settings:main');
-    if (!siteSettings.enable_mathjax_plugin) { return; }
-
-    loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
-
-      MathJax.Hub.Config({
-        "HTML-CSS": {
-          preferredFont: "TeX",
-          availableFonts: ["TeX"],
-          linebreaks: {
-            automatic: true
-          },
-          EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50)
-        },
-        tex2jax: {
-          inlineMath: [
-            ["$", "$"],
-            ["\\(", "\\)"]
-          ],
-          displayMath: [
-            ["$$", "$$"],
-            ["\\[", "\\]"]
-          ],
-          processEscapes: true
-        },
-        TeX: {
-          noUndefined: {
-            attributes: {
-              mathcolor: "red",
-              mathbackground: "#FFEEEE",
-              mathsize: "90%"
-            }
-          },
-          Macros: {
-            href: "{}"
-          }
-        },
-        messageStyle: "none"
-      });
-
-      decorateCooked(container, applyBody);
-      container.lookupFactory('view:composer').prototype.on("previewRefreshed", applyPreview);
-    });
+    oldCode(container);
   }
 };

--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -76,7 +76,9 @@ function initializePlugin(api) {
 
   loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
     mathJaxConfig();
-    api.decorateCooked($html => MathJax.Hub.Queue(["Typeset", MathJax.Hub, $html[0]]));
+    api.decorateCooked($html =>
+                       $.each($html, (i, domNode) =>
+                              MathJax.Hub.Queue(["Typeset", MathJax.Hub, domNode])));
   });
 }
 

--- a/assets/javascripts/initializers/mathjax.js.es6
+++ b/assets/javascripts/initializers/mathjax.js.es6
@@ -3,11 +3,11 @@
 import { decorateCooked } from 'discourse/lib/plugin-api';
 import loadScript from 'discourse/lib/load-script';
 
-function applyBody() {
+function oldApplyBody() {
   MathJax.Hub.Queue(["Typeset", MathJax.Hub, "topic"]);
 }
 
-function applyPreview() {
+function oldApplyPreview() {
   MathJax.Hub.Queue(["Typeset", MathJax.Hub, "wmd-preview"]);
   // if the caret is on the last line ensure preview scrolled to bottom
   const caretPosition = Discourse.Utilities.caretPosition(this.wmdInput[0]);
@@ -63,8 +63,8 @@ function oldCode(container) {
   loadScript(siteSettings.mathjax_url + '?config=' + siteSettings.mathjax_config, { scriptTag: true }).then(function () {
     mathJaxConfig();
 
-    decorateCooked(container, applyBody);
-    container.lookupFactory('view:composer').prototype.on("previewRefreshed", applyPreview);
+    decorateCooked(container, oldApplyBody);
+    container.lookupFactory('view:composer').prototype.on("previewRefreshed", oldApplyPreview);
   });
 }
 


### PR DESCRIPTION
This PR fixes #31, with some potential improvements over #30:

- it actually uses the documented API `decorateCooked` as intended. Neither `.d-editor-preview` nor "topic" are part of the documented API; the callback can just transform its argument.
- it tries to be compatible with the old API using the compatibility link.
